### PR TITLE
Fix: custom_json.read() function

### DIFF
--- a/utils/custom_json.py
+++ b/utils/custom_json.py
@@ -13,14 +13,9 @@ def read(FILENAME: str, FIELDS_LIST: list) -> list:
         json_data = json.load(json_file)['couriers']
     
     result = []
-    entry = {}
-
     for obj in json_data:
+        entry = {} # Создаем новый словарь для каждого объекта json
         for field in FIELDS_LIST:
             entry[field] = obj.get(field)
         result.append(entry)
     return result
-
-
-# if __name__ == "__main__":
-#     print(read(FILENAME, FIELDS_LIST))


### PR DESCRIPTION
Проблема в функции **read()** модуля **custom_json.py** заключалась в том, что добавлялся один и тот же словарь `entry` в список `result` на каждой итерации цикла, что приводит к тому, что все элементы в списке `result` ссылаются на один и тот же словарь. Чтобы исправить это, нужно создавать новый словарь `entry` на каждой итерации цикла.

В результате фикса, при парсинге JSON файла мы будем сохранять уникальные данные для каждого объекта JSON