### PR TITLE
Bug fix #10

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,7 +33,11 @@ def generate_fake_data():
 
 @app.route('/parse_json', methods=['POST'])
 def parse_json():
-    fields_list = request.form['cnvrt'].split(',')
+    # Получаем строку с полями из HTML формы
+    fields_input = request.form['cnvrt']
+    # Удаляем пробелы в начале и в конце каждого значения и разделяем строку на список
+    fields_list = [field.strip() for field in fields_input.split(',')]
+
     uploaded_file = request.files['file']
     filename = uploaded_file.filename
     uploaded_file.save(filename)

--- a/utils/custom_json.py
+++ b/utils/custom_json.py
@@ -13,14 +13,9 @@ def read(FILENAME: str, FIELDS_LIST: list) -> list:
         json_data = json.load(json_file)['couriers']
     
     result = []
-    entry = {}
-
     for obj in json_data:
+        entry = {} # Создаем новый словарь для каждого объекта json
         for field in FIELDS_LIST:
             entry[field] = obj.get(field)
         result.append(entry)
     return result
-
-
-# if __name__ == "__main__":
-#     print(read(FILENAME, FIELDS_LIST))


### PR DESCRIPTION
Проблема возникает из-за различий в способе разделения значений в строке, которую получаем из HTML формы.
Когда юзер вводит ключи полей JSON файла через запятую и пробел, они интерпретируются как одно значение с пробелом в начале, что приводит к неправильному разделению при использовании метода `split(',')`.

Чтобы пофиксить это, нужно обработать входную строку перед разделением на список. Можно использовать метод `strip()` для удаления лишних пробелов в начале и в конце каждого значения